### PR TITLE
Add React Router pages

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,16 +1,21 @@
 "use client";
 
 import Navigation from "@/components/Navigation";
-import HeroCarousel from "@/components/HeroCarousel";
-import FeaturesSection from "@/components/FeaturesSection";
 import Footer from "@/components/Footer";
+import { Routes, Route } from "react-router-dom";
+import Home from "@/pages/Home";
+import About from "@/pages/About";
+import Login from "@/pages/Login";
 
 export default function App() {
   return (
     <div className="min-h-screen bg-white dark:bg-gray-900">
       <Navigation />
-      <HeroCarousel />
-      <FeaturesSection />
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/about" element={<About />} />
+        <Route path="/login" element={<Login />} />
+      </Routes>
       <Footer />
     </div>
   );

--- a/frontend/src/components/Navigation.tsx
+++ b/frontend/src/components/Navigation.tsx
@@ -1,6 +1,7 @@
 import ThemeToggle from "./ThemeToggle";
 import { Button } from "@/components/ui/button";
 import { Zap } from "lucide-react";
+import { Link } from "react-router-dom";
 
 export default function Navigation() {
   return (
@@ -14,11 +15,19 @@ export default function Navigation() {
             <span className="text-xl font-bold text-gray-900 dark:text-white">DataFlow</span>
           </div>
           <div className="flex items-center space-x-4">
-            <button className="text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100 transition-colors duration-200 font-medium">Features</button>
-            <button className="text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100 transition-colors duration-200 font-medium">Pricing</button>
-            <button className="text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100 transition-colors duration-200 font-medium">About</button>
+            <Link
+              to="/about"
+              className="text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100 transition-colors duration-200 font-medium"
+            >
+              About
+            </Link>
             <ThemeToggle />
-            <Button className="bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 transform hover:scale-105 transition-all duration-200">Get Started</Button>
+            <Button
+              asChild
+              className="bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 transform hover:scale-105 transition-all duration-200"
+            >
+              <Link to="/login">Get Started</Link>
+            </Button>
           </div>
         </div>
       </div>

--- a/frontend/src/pages/About.tsx
+++ b/frontend/src/pages/About.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+export default function About() {
+  return (
+    <section className="max-w-3xl mx-auto p-4 text-gray-900 dark:text-white">
+      <h1 className="text-3xl font-bold mb-4">About</h1>
+      <p>This is a demo app showcasing React Router with Vite.</p>
+    </section>
+  );
+}

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import HeroCarousel from "@/components/HeroCarousel";
+import FeaturesSection from "@/components/FeaturesSection";
+
+export default function Home() {
+  return (
+    <>
+      <HeroCarousel />
+      <FeaturesSection />
+    </>
+  );
+}

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+export default function Login() {
+  return (
+    <div className="max-w-md mx-auto p-4">
+      <h1 className="text-3xl font-bold mb-4 text-gray-900 dark:text-white">Log In</h1>
+      <form className="space-y-4">
+        <Input type="email" placeholder="Email" />
+        <Input type="password" placeholder="Password" />
+        <Button type="submit" className="w-full">Log In</Button>
+      </form>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- integrate `react-router-dom` and add BrowserRouter in main
- create basic pages for Home, About, and Login
- wire up routes and update navigation

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_686e996cd4c8832783094e1ba71aa99f