### PR TITLE
Merge dashboard into frontend

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import { Routes, Route } from "react-router-dom";
 import LandingPage from "@/routes/LandingPage";
 import About from "@/routes/About";
 import Login from "@/routes/Login";
+import Dashboard from "@/routes/dashboard";
 
 export default function App() {
   return (
@@ -11,6 +12,7 @@ export default function App() {
       <Route path="/" element={<LandingPage />} />
       <Route path="/about" element={<About />} />
       <Route path="/login" element={<Login />} />
+      <Route path="/dashboard" element={<Dashboard />} />
     </Routes>
   );
 }

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -1,29 +1,11 @@
-import { useLayoutEffect, useState } from "react";
-import { Button } from "@/components/ui/button";
-import { Moon, Sun } from "lucide-react";
+"use client"
 
-function getInitialTheme(): "light" | "dark" {
-  if (typeof window !== "undefined") {
-    const stored = localStorage.getItem("theme");
-    if (stored === "dark") return "dark";
-    if (stored === "light") return "light";
-    if (window.matchMedia("(prefers-color-scheme: dark)").matches) return "dark";
-  }
-  return "light";
-}
+import { useTheme } from "@/components/theme-provider"
+import { Button } from "@/components/ui/button"
+import { Moon, Sun } from "lucide-react"
 
 export default function ThemeToggle() {
-  const [theme, setTheme] = useState<"light" | "dark">(getInitialTheme);
-
-  useLayoutEffect(() => {
-    if (theme === "dark") {
-      document.documentElement.classList.add("dark");
-      localStorage.setItem("theme", "dark");
-    } else {
-      document.documentElement.classList.remove("dark");
-      localStorage.setItem("theme", "light");
-    }
-  }, [theme]);
+  const { theme, setTheme } = useTheme()
 
   return (
     <Button
@@ -36,5 +18,5 @@ export default function ThemeToggle() {
       <Moon className="absolute h-4 w-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
       <span className="sr-only">Toggle theme</span>
     </Button>
-  );
+  )
 }

--- a/frontend/src/components/dashboard/app-sidebar.tsx
+++ b/frontend/src/components/dashboard/app-sidebar.tsx
@@ -1,0 +1,125 @@
+import { ChevronDown, Home, MessageSquare, Settings, Users, BarChart3, FileText, LogOut, User } from "lucide-react"
+import { Link, useLocation } from "react-router-dom"
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarRail,
+  SidebarTrigger,
+} from "@/components/ui/sidebar"
+
+const navigationItems = [
+  {
+    title: "Main",
+    items: [
+      { title: "Dashboard", icon: Home, url: "/dashboard" },
+      { title: "Messages", icon: MessageSquare, url: "/messages" },
+      { title: "Analytics", icon: BarChart3, url: "/analytics" },
+    ],
+  },
+  {
+    title: "Management",
+    items: [
+      { title: "Users", icon: Users, url: "/users" },
+      { title: "Documents", icon: FileText, url: "/documents" },
+      { title: "Settings", icon: Settings, url: "/settings" },
+    ],
+  },
+]
+
+export function AppSidebar() {
+  const location = useLocation()
+
+  return (
+    <Sidebar>
+      <SidebarHeader>
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuButton size="lg" className="data-[state=open]:bg-sidebar-accent">
+              <div className="flex aspect-square size-8 items-center justify-center rounded-lg bg-sidebar-primary text-sidebar-primary-foreground">
+                <BarChart3 className="size-4" />
+              </div>
+              <div className="flex flex-col gap-0.5 leading-none">
+                <span className="font-semibold">Dashboard</span>
+                <span className="text-xs">v1.0.0</span>
+              </div>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarHeader>
+
+      <SidebarContent>
+        {navigationItems.map((section) => (
+          <SidebarGroup key={section.title}>
+            <SidebarGroupLabel>{section.title}</SidebarGroupLabel>
+            <SidebarGroupContent>
+              <SidebarMenu>
+                {section.items.map((item) => (
+                  <SidebarMenuItem key={item.title}>
+                    <SidebarMenuButton asChild isActive={location.pathname === item.url}>
+                      <Link to={item.url}>
+                        <item.icon />
+                        <span>{item.title}</span>
+                      </Link>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                ))}
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+        ))}
+      </SidebarContent>
+
+      {/* Sidebar Toggle Tab */}
+      <div className="absolute -right-3 top-1/2 -translate-y-1/2 z-10">
+        <SidebarTrigger className="h-6 w-6 rounded-full border bg-background shadow-md hover:bg-accent">
+          <ChevronDown className="h-3 w-3 rotate-90" />
+        </SidebarTrigger>
+      </div>
+
+      <SidebarFooter>
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <SidebarMenuButton>
+                  <Avatar className="h-6 w-6">
+                    <AvatarImage src="/placeholder.svg?height=24&width=24" />
+                    <AvatarFallback>JD</AvatarFallback>
+                  </Avatar>
+                  <span>John Doe</span>
+                  <ChevronDown className="ml-auto" />
+                </SidebarMenuButton>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent side="top" className="w-[--radix-popper-anchor-width]">
+                <DropdownMenuItem>
+                  <User className="mr-2 h-4 w-4" />
+                  Profile
+                </DropdownMenuItem>
+                <DropdownMenuItem>
+                  <Settings className="mr-2 h-4 w-4" />
+                  Settings
+                </DropdownMenuItem>
+                <DropdownMenuItem className="text-red-600">
+                  <LogOut className="mr-2 h-4 w-4" />
+                  Sign Out
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarFooter>
+      <SidebarRail />
+    </Sidebar>
+  )
+}

--- a/frontend/src/components/dashboard/chat-interface.tsx
+++ b/frontend/src/components/dashboard/chat-interface.tsx
@@ -1,0 +1,79 @@
+"use client"
+
+import type React from "react"
+import { useState } from "react"
+import { Send } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+
+interface Message {
+  id: number
+  text: string
+  sender: "user" | "assistant"
+}
+
+export function ChatInterface() {
+  const [message, setMessage] = useState("")
+  const [messages, setMessages] = useState<Message[]>([
+    { id: 1, text: "Welcome to your dashboard! How can I help you today?", sender: "assistant" },
+  ])
+
+  const handleSendMessage = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (message.trim()) {
+      setMessages((prev) => [...prev, { id: Date.now(), text: message, sender: "user" }])
+      setMessage("")
+
+      // Simulate assistant response
+      setTimeout(() => {
+        setMessages((prev) => [
+          ...prev,
+          {
+            id: Date.now(),
+            text: "Thanks for your message! This is a demo response.",
+            sender: "assistant",
+          },
+        ])
+      }, 1000)
+    }
+  }
+
+  return (
+    <div className="border rounded-lg bg-card flex-1 flex flex-col w-full">
+      <div className="p-4 border-b">
+        <h3 className="font-semibold">Chat Assistant</h3>
+      </div>
+
+      {/* Messages */}
+      <div className="flex-1 overflow-y-auto p-4 space-y-4">
+        {messages.map((msg) => (
+          <div key={msg.id} className={`flex ${msg.sender === "user" ? "justify-end" : "justify-start"}`}>
+            <div
+              className={`max-w-xs lg:max-w-md px-4 py-2 rounded-lg ${
+                msg.sender === "user" ? "bg-primary text-primary-foreground" : "bg-muted"
+              }`}
+            >
+              {msg.text}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Message Input */}
+      <div className="p-4 border-t">
+        <form onSubmit={handleSendMessage} className="flex gap-2">
+          <Input
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            placeholder="Type your message..."
+            className="flex-1"
+          />
+          <Button type="submit" size="icon">
+            <Send className="h-4 w-4" />
+          </Button>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/dashboard/dashboard-layout.tsx
+++ b/frontend/src/components/dashboard/dashboard-layout.tsx
@@ -1,0 +1,21 @@
+"use client"
+
+import { useState } from "react"
+import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
+import { AppSidebar } from "./app-sidebar"
+import { TopNavigation } from "./top-navigation"
+import { MainContent } from "./main-content"
+
+export function DashboardLayout() {
+  const [isNavVisible, setIsNavVisible] = useState(true)
+
+  return (
+    <SidebarProvider>
+      <AppSidebar />
+      <SidebarInset className="flex flex-col h-screen w-full">
+        <TopNavigation isNavVisible={isNavVisible} setIsNavVisible={setIsNavVisible} />
+        <MainContent />
+      </SidebarInset>
+    </SidebarProvider>
+  )
+}

--- a/frontend/src/components/dashboard/main-content.tsx
+++ b/frontend/src/components/dashboard/main-content.tsx
@@ -1,0 +1,18 @@
+import { ChatInterface } from "./chat-interface"
+
+export function MainContent() {
+  return (
+    <main className="flex-1 overflow-auto h-full w-full">
+      <div className="p-6 h-full flex flex-col w-full">
+        <div className="w-full max-w-none flex-1 flex flex-col">
+          <div className="mb-6">
+            <h2 className="text-2xl font-bold mb-2">Welcome back!</h2>
+            <p className="text-muted-foreground">Start a conversation or explore your dashboard features.</p>
+          </div>
+
+          <ChatInterface />
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/frontend/src/components/dashboard/top-navigation.tsx
+++ b/frontend/src/components/dashboard/top-navigation.tsx
@@ -1,0 +1,51 @@
+"use client"
+
+import { Bell, Menu, X } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { SidebarTrigger } from "@/components/ui/sidebar"
+import ThemeToggle from "@/components/ThemeToggle"
+
+interface TopNavigationProps {
+  isNavVisible: boolean
+  setIsNavVisible: (visible: boolean) => void
+}
+
+export function TopNavigation({ isNavVisible, setIsNavVisible }: TopNavigationProps) {
+  return (
+    <>
+      {/* Collapsible Top Navigation */}
+      <div
+        className={`transition-all duration-300 ease-in-out ${isNavVisible ? "h-16" : "h-0"} overflow-hidden border-b`}
+      >
+        <header className="flex h-16 shrink-0 items-center justify-between bg-background px-4">
+          <div className="flex items-center gap-2">
+            <SidebarTrigger className="-ml-1" />
+            <h1 className="text-lg font-semibold">Dashboard</h1>
+          </div>
+          <div className="flex items-center gap-2">
+            <ThemeToggle />
+            <Button variant="ghost" size="icon">
+              <Bell className="h-4 w-4" />
+            </Button>
+            <Button variant="ghost" size="icon" onClick={() => setIsNavVisible(!isNavVisible)}>
+              {isNavVisible ? <X className="h-4 w-4" /> : <Menu className="h-4 w-4" />}
+            </Button>
+          </div>
+        </header>
+      </div>
+
+      {/* Toggle button when navbar is hidden */}
+      {!isNavVisible && (
+        <Button
+          variant="outline"
+          size="sm"
+          className="absolute top-2 right-2 z-10 bg-transparent"
+          onClick={() => setIsNavVisible(true)}
+        >
+          <Menu className="h-4 w-4" />
+        </Button>
+      )}
+    </>
+  )
+}

--- a/frontend/src/components/theme-provider.tsx
+++ b/frontend/src/components/theme-provider.tsx
@@ -1,0 +1,69 @@
+"use client"
+
+import type React from "react"
+import { createContext, useContext, useEffect, useState } from "react"
+
+type Theme = "dark" | "light" | "system"
+
+type ThemeProviderProps = {
+  children: React.ReactNode
+  defaultTheme?: Theme
+  storageKey?: string
+}
+
+type ThemeProviderState = {
+  theme: Theme
+  setTheme: (theme: Theme) => void
+}
+
+const initialState: ThemeProviderState = {
+  theme: "system",
+  setTheme: () => null,
+}
+
+const ThemeProviderContext = createContext<ThemeProviderState>(initialState)
+
+export function ThemeProvider({
+  children,
+  defaultTheme = "dark",
+  storageKey = "vite-ui-theme",
+  ...props
+}: ThemeProviderProps) {
+  const [theme, setTheme] = useState<Theme>(() => (localStorage.getItem(storageKey) as Theme) || defaultTheme)
+
+  useEffect(() => {
+    const root = window.document.documentElement
+
+    root.classList.remove("light", "dark")
+
+    if (theme === "system") {
+      const systemTheme = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light"
+      root.classList.add(systemTheme)
+      return
+    }
+
+    root.classList.add(theme)
+  }, [theme])
+
+  const value = {
+    theme,
+    setTheme: (theme: Theme) => {
+      localStorage.setItem(storageKey, theme)
+      setTheme(theme)
+    },
+  }
+
+  return (
+    <ThemeProviderContext.Provider {...props} value={value}>
+      {children}
+    </ThemeProviderContext.Provider>
+  )
+}
+
+export const useTheme = () => {
+  const context = useContext(ThemeProviderContext)
+
+  if (context === undefined) throw new Error("useTheme must be used within a ThemeProvider")
+
+  return context
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,12 +2,15 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App';
+import { ThemeProvider } from '@/components/theme-provider';
 import './styles/index.css';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <ThemeProvider defaultTheme="dark" storageKey="vite-ui-theme">
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </ThemeProvider>
   </React.StrictMode>
 );

--- a/frontend/src/routes/dashboard/index.tsx
+++ b/frontend/src/routes/dashboard/index.tsx
@@ -1,0 +1,5 @@
+import { DashboardLayout } from "@/components/dashboard/dashboard-layout"
+
+export default function Dashboard() {
+  return <DashboardLayout />
+}


### PR DESCRIPTION
## Summary
- integrate dashboard components into frontend
- use a theme provider wrapper across the app
- keep theme toggle as simple button using the new provider
- add dashboard route

## Testing
- `npx tsc --noEmit`
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_686fcc676ce88327814ae53fce346e8d