### PR TITLE
Use CSS palette for component colors

### DIFF
--- a/frontend/src/components/FeaturesSection.tsx
+++ b/frontend/src/components/FeaturesSection.tsx
@@ -4,30 +4,30 @@ import { CheckCircle, Globe, Shield, TrendingUp, Users, Zap } from "lucide-react
 
 export default function FeaturesSection() {
   return (
-    <section className="py-24 bg-gray-50 dark:bg-gray-900">
+    <section className="py-24 bg-background">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-16">
-          <h2 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-white mb-4">Why Choose LEVARE AI?</h2>
-          <p className="text-xl text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
+          <h2 className="text-3xl md:text-4xl font-bold text-foreground mb-4">Why Choose LEVARE AI?</h2>
+          <p className="text-xl text-muted-foreground max-w-3xl mx-auto">
             I put this section in because I thought it would be a good idea to highlight the key features and benefits of our platform.
           </p>
         </div>
         <div className="grid md:grid-cols-3 gap-8 mb-16">
           {[
             {
-              icon: <Zap className="h-8 w-8 text-blue-600" />,
+              icon: <Zap className="h-8 w-8 text-accent" />,
               title: "Something here?",
               description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut commodo ut ante eu pharetra. Nam purus felis, luctus vel cursus non, posuere non lorem.",
               benefits: ["Sub-second query responses", "Real-time data streaming", "Instant insights"],
             },
             {
-              icon: <Shield className="h-8 w-8 text-green-600" />,
+              icon: <Shield className="h-8 w-8 text-accent" />,
               title: "Security?",
               description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut commodo ut ante eu pharetra. Nam purus felis, luctus vel cursus non, posuere non lorem.",
               benefits: ["SOC 2 Type II certified", "GDPR stuff?", "encryption"],
             },
             {
-              icon: <Users className="h-8 w-8 text-purple-600" />,
+              icon: <Users className="h-8 w-8 text-accent" />,
               title: "Team Collaboration?",
               description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut commodo ut ante eu pharetra. Nam purus felis, luctus vel cursus non, posuere non lorem.",
               benefits: ["Role-based access control", "Real-time collaboration", "Audit trails"],
@@ -35,18 +35,18 @@ export default function FeaturesSection() {
           ].map((feature, index) => (
             <Card
               key={index}
-              className="group hover:shadow-xl transition-all duration-300 transform hover:-translate-y-2 border-0 shadow-lg dark:bg-gray-800 dark:shadow-gray-900/20"
+              className="group hover:shadow-xl transition-all duration-300 transform hover:-translate-y-2 border-0 shadow-lg bg-card dark:shadow-gray-900/20"
             >
               <CardContent className="p-8">
-                <div className="mb-6 p-3 bg-gray-100 dark:bg-gray-700 rounded-lg w-fit group-hover:scale-110 transition-transform duration-200">
+                <div className="mb-6 p-3 bg-muted rounded-lg w-fit group-hover:scale-110 transition-transform duration-200">
                   {feature.icon}
                 </div>
-                <h3 className="text-xl font-semibold text-gray-900 dark:text-white mb-4">{feature.title}</h3>
-                <p className="text-gray-600 dark:text-gray-300 mb-6 leading-relaxed">{feature.description}</p>
+                <h3 className="text-xl font-semibold text-foreground mb-4">{feature.title}</h3>
+                <p className="text-muted-foreground mb-6 leading-relaxed">{feature.description}</p>
                 <ul className="space-y-2">
                   {feature.benefits.map((benefit, idx) => (
-                    <li key={idx} className="flex items-center text-sm text-gray-500 dark:text-gray-400">
-                      <CheckCircle className="h-4 w-4 text-green-500 mr-2 flex-shrink-0" />
+                    <li key={idx} className="flex items-center text-sm text-muted-foreground">
+                      <CheckCircle className="h-4 w-4 text-accent mr-2 flex-shrink-0" />
                       {benefit}
                     </li>
                   ))}
@@ -58,11 +58,11 @@ export default function FeaturesSection() {
 
         {/* Second Section */}
 
-        <div className="bg-white dark:bg-gray-800 rounded-2xl p-8 md:p-12 shadow-lg dark:shadow-gray-900/20">
+        <div className="bg-card rounded-2xl p-8 md:p-12 shadow-lg dark:shadow-gray-900/20">
           <div className="grid lg:grid-cols-2 gap-12 items-center">
             <div>
-              <h3 className="text-2xl md:text-3xl font-bold text-gray-900 dark:text-white mb-6">Transform Data Into Actionable Insights</h3>
-              <p className="text-gray-600 dark:text-gray-300 mb-8 leading-relaxed">
+              <h3 className="text-2xl md:text-3xl font-bold text-foreground mb-6">Transform Data Into Actionable Insights</h3>
+              <p className="text-muted-foreground mb-8 leading-relaxed">
                 Our platform combines the power of artificial intelligence with intuitive design to help you make data-driven decisions faster than ever before. From small startups to enterprise organizations, we provide the tools you need to succeed.
               </p>
               <div className="grid sm:grid-cols-2 gap-6">
@@ -74,30 +74,30 @@ export default function FeaturesSection() {
                 ].map((stat, index) => (
                   <div
                     key={index}
-                    className="text-center p-4 bg-gray-50 dark:bg-gray-700 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-600 transition-colors duration-200"
+                    className="text-center p-4 bg-muted rounded-lg hover:bg-muted/80 transition-colors duration-200"
                   >
-                    <div className="text-2xl font-bold text-blue-600 dark:text-blue-400">{stat.value}</div>
-                    <div className="text-sm text-gray-600 dark:text-gray-300">{stat.label}</div>
+                    <div className="text-2xl font-bold text-accent">{stat.value}</div>
+                    <div className="text-sm text-muted-foreground">{stat.label}</div>
                   </div>
                 ))}
               </div>
             </div>
             <div className="relative">
-              <div className="absolute inset-0 bg-gradient-to-r from-blue-600 to-purple-600 rounded-2xl transform rotate-3" />
-              <div className="relative bg-white dark:bg-gray-800 rounded-2xl p-8 border dark:border-gray-700 shadow-lg dark:shadow-gray-900/20">
+              <div className="absolute inset-0 bg-gradient-to-r from-accent to-chart-5 rounded-2xl transform rotate-3" />
+              <div className="relative bg-card rounded-2xl p-8 border border-border shadow-lg dark:shadow-gray-900/20">
                 <div className="space-y-4">
                   <div className="flex items-center justify-between">
-                    <span className="text-sm text-gray-500 dark:text-gray-400">Revenue Growth</span>
-                    <span className="text-sm font-semibold text-green-600 dark:text-green-400">+127%</span>
+                    <span className="text-sm text-muted-foreground">Revenue Growth</span>
+                    <span className="text-sm font-semibold text-accent">+127%</span>
                   </div>
-                  <div className="h-2 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
-                    <div className="h-full bg-gradient-to-r from-green-500 to-blue-500 rounded-full w-4/5" />
+                  <div className="h-2 bg-muted rounded-full overflow-hidden">
+                    <div className="h-full bg-gradient-to-r from-accent to-chart-5 rounded-full w-4/5" />
                   </div>
                   <div className="grid grid-cols-3 gap-4 pt-4">
                     {["Q1", "Q2", "Q3"].map((quarter, idx) => (
                       <div key={quarter} className="text-center">
-                        <div className={`h-16 bg-gradient-to-t from-blue-500 to-purple-500 rounded mb-2`} style={{ height: `${(idx + 1) * 20}px` }} />
-                        <span className="text-xs text-gray-500 dark:text-gray-400">{quarter}</span>
+                        <div className={`h-16 bg-gradient-to-t from-accent to-chart-5 rounded mb-2`} style={{ height: `${(idx + 1) * 20}px` }} />
+                        <span className="text-xs text-muted-foreground">{quarter}</span>
                       </div>
                     ))}
                   </div>

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -7,8 +7,8 @@ export default function Footer() {
         <div className="grid md:grid-cols-4 gap-8">
           <div className="space-y-4">
             <div className="flex items-center space-x-2">
-              <div className="h-8 w-8 bg-gradient-to-r from-blue-600 to-purple-600 rounded-lg flex items-center justify-center">
-                <Zap className="h-5 w-5 text-white" />
+              <div className="h-8 w-8 bg-gradient-to-r from-accent to-chart-5 rounded-lg flex items-center justify-center">
+                <Zap className="h-5 w-5 text-primary-foreground" />
               </div>
               <span className="text-xl font-bold">LEVARE AI</span>
             </div>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -4,33 +4,33 @@ import { Link } from "react-router-dom";
 
 export default function Navigation() {
   return (
-    <nav className="sticky top-0 z-50 bg-white/95 dark:bg-gray-900/95 backdrop-blur-sm border-b dark:border-gray-800">
+    <nav className="sticky top-0 z-50 bg-background/95 backdrop-blur-sm border-b border-border">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center h-16">
           <div className="flex items-center space-x-2">
-            <Link to="/" className="text-xl font-bold text-gray-900 dark:text-white">
+            <Link to="/" className="text-xl font-bold text-foreground">
               LEVARE AI
             </Link>
           </div>
           <div className="flex items-center space-x-4">
-            <button className="text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100 transition-colors duration-200 font-medium">Features</button>
-            <button className="text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100 transition-colors duration-200 font-medium">Pricing</button>
+            <button className="text-muted-foreground hover:text-foreground transition-colors duration-200 font-medium">Features</button>
+            <button className="text-muted-foreground hover:text-foreground transition-colors duration-200 font-medium">Pricing</button>
             <Link
               to="/about"
-              className="text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100 transition-colors duration-200 font-medium"
+              className="text-muted-foreground hover:text-foreground transition-colors duration-200 font-medium"
             >
               About us
             </Link>
             <ThemeToggle />
             <Button
               asChild
-              className="bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 transform hover:scale-105 transition-all duration-200"
+              className="bg-gradient-to-r from-accent to-chart-5 hover:from-accent hover:to-chart-5 transform hover:scale-105 transition-all duration-200"
             >
               <Link to="/dashboard">Dashboard</Link>
             </Button>
             <Button
               asChild
-              className="bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 transform hover:scale-105 transition-all duration-200"
+              className="bg-gradient-to-r from-accent to-chart-5 hover:from-accent hover:to-chart-5 transform hover:scale-105 transition-all duration-200"
             >
               <Link to="/login">Get Started</Link>
             </Button>

--- a/frontend/src/components/HeroBackground.tsx
+++ b/frontend/src/components/HeroBackground.tsx
@@ -9,9 +9,9 @@ export function HeroBackground() {
   return (
     <div className="absolute inset-0 overflow-hidden">
       {/* Blobs */}
-      <div className="absolute w-[70vw] h-[70vw] bg-purple-700 opacity-40 blur-2xl rounded-full animate-blob1" />
-      <div className="absolute w-[50vw] h-[50vw] bg-pink-500 opacity-40 blur-2xl rounded-full animate-blob2 top-1/2 left-1/3" />
-      <div className="absolute w-[90vw] h-[90vw] bg-indigo-600 opacity-40 blur-2xl rounded-full animate-blob3 top-1/4 left-1/2" />
+      <div className="absolute w-[70vw] h-[70vw] bg-accent opacity-40 blur-2xl rounded-full animate-blob1" />
+      <div className="absolute w-[50vw] h-[50vw] bg-accent opacity-40 blur-2xl rounded-full animate-blob2 top-1/2 left-1/3" />
+      <div className="absolute w-[90vw] h-[90vw] bg-accent opacity-40 blur-2xl rounded-full animate-blob3 top-1/4 left-1/2" />
 
       {/* Mouse Light 
       <div className="absolute inset-0 pointer-events-none mix-blend-screen">

--- a/frontend/src/components/HeroCarousel.tsx
+++ b/frontend/src/components/HeroCarousel.tsx
@@ -34,8 +34,8 @@ export default function HeroCarousel() {
       subtitle: "Unlock insights that drive growth",
       description:
         "Empowering business leaders with intelligent agents. Our platform turns ambition into everyday action.",
-      icon: <TrendingUp className="h-16 w-16 text-blue-500" />,
-      gradient: "from-blue-600 to-purple-600",
+      icon: <TrendingUp className="h-16 w-16 text-accent" />,
+      gradient: "from-accent to-chart-5",
       features: ["something", "something else", "Custom Dashboards"],
     },
     {
@@ -43,8 +43,8 @@ export default function HeroCarousel() {
       subtitle: "ipsum dolor sit amet",
       description:
         "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
-      icon: <Globe className="h-16 w-16 text-green-500" />,
-      gradient: "from-green-600 to-teal-600",
+      icon: <Globe className="h-16 w-16 text-accent" />,
+      gradient: "from-accent to-chart-5",
       features: ["Global CDN", "Auto-scaling", "24/7 Monitoring"],
     },
     {
@@ -52,8 +52,8 @@ export default function HeroCarousel() {
       subtitle: "join now.., ",
       description:
         "register interest etc. etc. Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-      icon: <CheckCircle className="h-16 w-16 text-orange-500" />,
-      gradient: "from-orange-600 to-red-600",
+      icon: <CheckCircle className="h-16 w-16 text-accent" />,
+      gradient: "from-accent to-chart-5",
       features: ["join up", "it's cool", "blah"],
       cta: true,
     },
@@ -65,35 +65,35 @@ export default function HeroCarousel() {
         <CarouselContent>
           {heroSlides.map((slide, index) => (
             <CarouselItem key={index}>
-              <div className="relative min-h-[600px] bg-black text-white overflow-hidden">
+              <div className="relative min-h-[600px] bg-primary text-primary-foreground overflow-hidden">
 
                 <HeroBackground />
 
                 {/* Slide Gradient */}
                 <div className={`absolute inset-0 bg-gradient-to-br ${slide.gradient} opacity-30`} />
-                <div className="absolute inset-0 bg-black/10" />
+                <div className="absolute inset-0 bg-primary/10" />
 
                 {/* Slide Content */}
                 <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-24">
                   <div className="grid lg:grid-cols-[3fr_1fr] gap-6 items-center">
                     <div className="space-y-8">
                       <div className="space-y-4">
-                        <Badge variant="secondary" className="bg-white/20 text-white border-white/30">
+                        <Badge variant="secondary" className="bg-primary-foreground/20 text-primary-foreground border-primary-foreground/30">
                           {slide.subtitle}
                         </Badge>
                         <h1 className="text-4xl md:text-6xl font-bold leading-tight">{slide.title}</h1>
-                        <p className="text-xl text-white/90 leading-relaxed">{slide.description}</p>
+                        <p className="text-xl text-primary-foreground/90 leading-relaxed">{slide.description}</p>
                       </div>
                       <div className="flex flex-wrap gap-3">
                         {slide.features.map((feature, idx) => (
-                          <Badge key={idx} variant="outline" className="bg-white/10 text-white border-white/30">
+                          <Badge key={idx} variant="outline" className="bg-primary-foreground/10 text-primary-foreground border-primary-foreground/30">
                             {feature}
                           </Badge>
                         ))}
                       </div>
                       {slide.cta && (
                         <div className="flex flex-col sm:flex-row gap-4">
-                          <Button size="lg" className="bg-white text-gray-900 hover:bg-gray-100 transform hover:scale-105 transition-all duration-200">
+                          <Button size="lg" className="bg-primary-foreground text-primary hover:bg-primary-foreground/90 transform hover:scale-105 transition-all duration-200">
                             Start Free Trial
                             <ArrowRight className="ml-2 h-5 w-5" />
                           </Button>
@@ -103,8 +103,8 @@ export default function HeroCarousel() {
                     {/* Icon}
                     <div className="flex justify-center"> 
                       <div className="relative">
-                        <div className="absolute inset-0 bg-white/20 rounded-full blur-3xl transform scale-150" />
-                        <div className="relative bg-white/10 backdrop-blur-sm rounded-2xl p-12 border border-white/20 hover:bg-white/20 transition-all duration-300 transform hover:scale-105">
+                        <div className="absolute inset-0 bg-primary-foreground/20 rounded-full blur-3xl transform scale-150" />
+                        <div className="relative bg-primary-foreground/10 backdrop-blur-sm rounded-2xl p-12 border border-primary-foreground/20 hover:bg-primary-foreground/20 transition-all duration-300 transform hover:scale-105">
                           {slide.icon}
                         </div>
                       </div>     
@@ -116,14 +116,14 @@ export default function HeroCarousel() {
             </CarouselItem>
           ))}
         </CarouselContent>
-        <CarouselPrevious className="left-4 bg-white/20 border-white/30 text-white hover:bg-white/30" />
-        <CarouselNext className="right-4 bg-white/20 border-white/30 text-white hover:bg-white/30" />
+        <CarouselPrevious className="left-4 bg-primary-foreground/20 border-primary-foreground/30 text-primary-foreground hover:bg-primary-foreground/30" />
+        <CarouselNext className="right-4 bg-primary-foreground/20 border-primary-foreground/30 text-primary-foreground hover:bg-primary-foreground/30" />
       </Carousel>
       <div className="absolute bottom-6 left-1/2 transform -translate-x-1/2 flex space-x-2">
         {heroSlides.map((_, index) => (
           <button
             key={index}
-            className={`w-3 h-3 rounded-full transition-all duration-200 ${current === index ? "bg-white" : "bg-white/50"}`}
+            className={`w-3 h-3 rounded-full transition-all duration-200 ${current === index ? "bg-primary-foreground" : "bg-primary-foreground/50"}`}
             onClick={() => api?.scrollTo(index)}
           />
         ))}

--- a/frontend/src/components/dashboard/app-sidebar.tsx
+++ b/frontend/src/components/dashboard/app-sidebar.tsx
@@ -110,7 +110,7 @@ export function AppSidebar() {
                   <Settings className="mr-2 h-4 w-4" />
                   Settings
                 </DropdownMenuItem>
-                <DropdownMenuItem className="text-red-600">
+                <DropdownMenuItem className="text-destructive">
                   <LogOut className="mr-2 h-4 w-4" />
                   Sign Out
                 </DropdownMenuItem>

--- a/frontend/src/components/ui/toast.tsx
+++ b/frontend/src/components/ui/toast.tsx
@@ -77,7 +77,7 @@ const ToastClose = React.forwardRef<
   <ToastPrimitives.Close
     ref={ref}
     className={cn(
-      "absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
+      "absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive group-[.destructive]:focus:ring-offset-destructive",
       className
     )}
     toast-close=""

--- a/frontend/src/routes/About.tsx
+++ b/frontend/src/routes/About.tsx
@@ -3,11 +3,11 @@ import Footer from "@/components/Footer";
 
 export default function About() {
   return (
-    <div className="min-h-screen bg-white dark:bg-gray-900 flex flex-col">
+    <div className="min-h-screen bg-background flex flex-col">
       <Navigation />
       <main className="flex-1 max-w-3xl mx-auto px-4 py-12 text-center">
-        <h1 className="text-3xl font-bold mb-4 text-gray-900 dark:text-white">About</h1>
-        <p className="text-gray-700 dark:text-gray-300">
+        <h1 className="text-3xl font-bold mb-4 text-foreground">About</h1>
+        <p className="text-muted-foreground">
           This is the about page.
         </p>
       </main>

--- a/frontend/src/routes/LandingPage.tsx
+++ b/frontend/src/routes/LandingPage.tsx
@@ -5,7 +5,7 @@ import Footer from "@/components/Footer";
 
 export default function LandingPage() {
   return (
-    <div className="min-h-screen bg-white dark:bg-gray-900">
+    <div className="min-h-screen bg-background">
       <Navigation />
       <HeroCarousel />
       <FeaturesSection />

--- a/frontend/src/routes/Login.tsx
+++ b/frontend/src/routes/Login.tsx
@@ -3,11 +3,11 @@ import Footer from "@/components/Footer";
 
 export default function Login() {
   return (
-    <div className="min-h-screen bg-white dark:bg-gray-900 flex flex-col">
+    <div className="min-h-screen bg-background flex flex-col">
       <Navigation />
       <main className="flex-1 max-w-md mx-auto px-4 py-12">
-        <h1 className="text-3xl font-bold mb-4 text-gray-900 dark:text-white text-center">Log In</h1>
-        <p className="text-gray-700 dark:text-gray-300 text-center">
+        <h1 className="text-3xl font-bold mb-4 text-foreground text-center">Log In</h1>
+        <p className="text-muted-foreground text-center">
           Login form goes here.
         </p>
       </main>


### PR DESCRIPTION
## Summary
- refactor header, footer, hero, and feature sections to use palette variables
- replace hard-coded page colors with palette classes
- adjust dashboard sidebar and toast component colors

## Testing
- `pnpm build` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*

------
https://chatgpt.com/codex/tasks/task_e_687120bc722083279dbda78793fd6599